### PR TITLE
ENH: enable urlpath and image_urlpath that isn't linked to downloadnb

### DIFF
--- a/sphinx_tojupyter/__init__.py
+++ b/sphinx_tojupyter/__init__.py
@@ -70,6 +70,8 @@ def setup(app):
     app.add_config_value("tojupyter_download_nb_urlpath", None, "jupyter")
     app.add_config_value("tojupyter_download_nb_image_urlpath", None, "jupyter")
     app.add_config_value("tojupyter_images_markdown", False, "jupyter")
+    app.add_config_value("tojupyter_urlpath", None, "jupyter")
+    app.add_config_value("tojupyter_image_urlpath", None, "jupyter")
 
     # Jupyter pdf options
     app.add_config_value("tojupyter_latex_template", None, "jupyter")

--- a/sphinx_tojupyter/builders/jupyter.py
+++ b/sphinx_tojupyter/builders/jupyter.py
@@ -147,12 +147,20 @@ class JupyterBuilder(Builder):
         doctree = doctree.deepcopy()
         destination = docutils.io.StringOutput(encoding="utf-8")
         ### print an output for downloading notebooks as well with proper links if variable is set
+        if "tojupyter_urlpath" in self.config:
+            self.writer._set_ref_urlpath(self.config["tojupyter_urlpath"])
+        else:
+            self.writer._set_ref_urlpath(None)
+        if "tojupyter_image_urlpath" in self.config:
+            self.writer._set_tojupyter_image_urlpath((self.config["tojupyter_image_urlpath"]))
+        else:
+            self.writer._set_tojupyter_image_urlpath(None)
         if "tojupyter_download_nb" in self.config and self.config["tojupyter_download_nb"]:
 
             outfilename = os.path.join(self.downloadsdir, os_path(docname) + self.out_suffix)
             ensuredir(os.path.dirname(outfilename))
             self.writer._set_ref_urlpath(self.config["tojupyter_download_nb_urlpath"])
-            self.writer._set_tojupyter_download_nb_image_urlpath((self.config["tojupyter_download_nb_image_urlpath"]))
+            self.writer._set_tojupyter_image_urlpath((self.config["tojupyter_download_nb_image_urlpath"]))
             self.writer.write(doctree, destination)
 
             # get a NotebookNode object from a string
@@ -174,8 +182,6 @@ class JupyterBuilder(Builder):
                     self._execute_notebook_class.execute_notebook(self, nb, docname, self.download_execution_vars, self.download_execution_vars['futures'])
 
         ### output notebooks for executing
-        self.writer._set_ref_urlpath(None)
-        self.writer._set_tojupyter_download_nb_image_urlpath(None)
         self.writer.write(doctree, destination)
 
         # get a NotebookNode object from a string

--- a/sphinx_tojupyter/builders/jupyterpdf.py
+++ b/sphinx_tojupyter/builders/jupyterpdf.py
@@ -144,7 +144,7 @@ class JupyterPDFBuilder(Builder):
 
         ### output notebooks for executing for single pdfs, the urlpath should be set to website url
         self.writer._set_ref_urlpath(self.config["tojupyter_pdf_urlpath"])
-        self.writer._set_tojupyter_download_nb_image_urlpath(None)
+        self.writer._set_tojupyter_image_urlpath(None)
         self.writer.write(doctree, destination)
 
         # get a NotebookNode object from a string

--- a/sphinx_tojupyter/writers/jupyter.py
+++ b/sphinx_tojupyter/writers/jupyter.py
@@ -29,11 +29,11 @@ class JupyterWriter(docutils.writers.Writer):
         """
         self.builder.urlpath = urlpath
 
-    def _set_tojupyter_download_nb_image_urlpath(self, urlpath=None):
+    def _set_tojupyter_image_urlpath(self, urlpath=None):
         """
         Set a urlpath to be used to prepend image paths in the notebook, so that it can be different for different targets.
         """
-        self.builder.tojupyter_download_nb_image_urlpath = urlpath
+        self.builder.tojupyter_image_urlpath = urlpath
 
     def _identify_translator(self, builder):
         """

--- a/sphinx_tojupyter/writers/translate_all.py
+++ b/sphinx_tojupyter/writers/translate_all.py
@@ -204,10 +204,10 @@ class JupyterTranslator(JupyterCodeTranslator, object):
             return
         uri = node.attributes["uri"]
         self.images.append(uri)             #TODO: list of image files
-        if self.tojupyter_download_nb_image_urlpath:
+        if self.tojupyter_image_urlpath:
             for file_path in self.tojupyter_static_file_path:
                 if file_path in uri:
-                    uri = uri.replace(file_path +"/", self.tojupyter_download_nb_image_urlpath)
+                    uri = uri.replace(file_path +"/", self.tojupyter_image_urlpath)
                     break  #don't need to check other matches
         attrs = node.attributes
         if self.tojupyter_images_markdown:

--- a/sphinx_tojupyter/writers/translate_code.py
+++ b/sphinx_tojupyter/writers/translate_code.py
@@ -44,7 +44,7 @@ class JupyterCodeTranslator(docutils.nodes.GenericNodeVisitor):
         self.tojupyter_ignore_skip_test = builder.config["tojupyter_ignore_skip_test"]
         self.tojupyter_lang_synonyms = builder.config["tojupyter_lang_synonyms"]
         self.tojupyter_target_html = builder.config["tojupyter_target_html"]
-        self.tojupyter_download_nb_image_urlpath = builder.tojupyter_download_nb_image_urlpath
+        self.tojupyter_image_urlpath = builder.tojupyter_image_urlpath
         self.tojupyter_images_markdown = builder.config["tojupyter_images_markdown"]
         self.tojupyter_target_pdf = builder.config["tojupyter_target_pdf"]
         self.tojupyter_pdf_showcontentdepth = builder.config["tojupyter_pdf_showcontentdepth"]


### PR DESCRIPTION
This can be used with `tojuptyer_target_html = True` to support `download` notebook sets