### PR TITLE
MAIN: Remove overrides option

### DIFF
--- a/sphinx_tojupyter/__init__.py
+++ b/sphinx_tojupyter/__init__.py
@@ -72,7 +72,6 @@ def setup(app):
     app.add_config_value("tojupyter_write_metadata", False, "jupyter")
     app.add_config_value("tojupyter_static_file_path", [], "jupyter")
     app.add_config_value("tojupyter_header_block", None, "jupyter")
-    app.add_config_value("tojupyter_options", None, "jupyter")
     app.add_config_value("tojupyter_default_lang", "python3", "jupyter")
     app.add_config_value("tojupyter_lang_synonyms", [], "jupyter")
     app.add_config_value("tojupyter_drop_solutions", True, "jupyter")

--- a/sphinx_tojupyter/builders/jupyter.py
+++ b/sphinx_tojupyter/builders/jupyter.py
@@ -57,19 +57,6 @@ class JupyterBuilder(Builder):
                 "Set default language to python3"
                 .format(def_lng))
             self.config["tojupyter_default_lang"] = "python3"
-        # If the user has overridden anything on the command line, set these things which have been overridden.
-        instructions = []
-        overrides = self.config['tojupyter_options']
-        if overrides:
-            instructions = overrides.split(",")
-
-        for instruction in instructions:
-            if instruction:
-                if instruction == 'code_only':
-                    self.config["tojupyter_conversion_mode"] = "code"
-                else:
-                    # Fail on unrecognised command.
-                    self.logger.warning("Unrecognise command line parameter " + instruction + ", ignoring.")
 
         #threads per worker for dask distributed processing
         if "tojupyter_threads_per_worker" in self.config:

--- a/sphinx_tojupyter/builders/jupyterpdf.py
+++ b/sphinx_tojupyter/builders/jupyterpdf.py
@@ -66,20 +66,7 @@ class JupyterPDFBuilder(Builder):
                 "Set default language to python3"
                 .format(def_lng))
             self.config["tojupyter_default_lang"] = "python3"
-        # If the user has overridden anything on the command line, set these things which have been overridden.
-        instructions = []
-        overrides = self.config['tojupyter_options']
-        if overrides:
-            instructions = overrides.split(",")
-
-        for instruction in instructions:
-            if instruction:
-                if instruction == 'code_only':
-                    self.config["tojupyter_conversion_mode"] = "code"
-                else:
-                    # Fail on unrecognised command.
-                    self.logger.warning("Unrecognise command line parameter " + instruction + ", ignoring.")
-
+        
         #threads per worker for dask distributed processing
         if "tojupyter_threads_per_worker" in self.config:
             self.threads_per_worker = self.config["tojupyter_threads_per_worker"]


### PR DESCRIPTION
This PR removes `overrides` option and no longer needed. want builders to be used directly for simplicity. 