### PR TITLE
ENH: Add support for sphinx-exercise (enumerated titles)

### DIFF
--- a/sphinx_tojupyter/builders/jupyter.py
+++ b/sphinx_tojupyter/builders/jupyter.py
@@ -131,6 +131,7 @@ class JupyterBuilder(Builder):
     def write_doc(self, docname, doctree):
         # work around multiple string % tuple issues in docutils;
         # replace tuples in attribute values with lists
+        self.docname = docname
         doctree = doctree.deepcopy()
         destination = docutils.io.StringOutput(encoding="utf-8")
         ### print an output for downloading notebooks as well with proper links if variable is set

--- a/sphinx_tojupyter/writers/translate_all.py
+++ b/sphinx_tojupyter/writers/translate_all.py
@@ -969,6 +969,30 @@ class JupyterTranslator(JupyterCodeTranslator, object):
         if self.in_toctree:
             self.markdown_lines.append("\n")
 
+    # 
+    # Support for sphinx-exercise (enumberable nodes)
+    # This work in sphinx-exercise is done in a post_transform
+    # and relies on html translator to populate the numref
+    # targets
+    #
+
+    def visit_exercise_enumerable_node(self, node):
+        """
+        TODO: This should be moved to spinx-exercise visit_ and depart_ methods
+        """
+        title = node.children[0].get("title", "")
+        label = node.get("label", "")
+        docname = self.builder.docname
+        fig_num = self.builder.env.toc_fignumbers.get(docname, {})
+        try:
+            number = fig_num["exercise"][label]
+            number = ".".join(map(str, number))
+            title_text = self.builder.config.numfig_format["exercise"] % number
+        except:
+            logger.warn("[sphinx-tojupyter] Unable to parse enumerable exercise node with numfig format")
+        title = node.children[0]
+        title += nodes.Text(title_text)
+
     # ================
     # general methods
     # ================


### PR DESCRIPTION
This may be `temporary` but adding this here to support `numref` exercises from `sphinx-exercise` so the `exercise titles` can be resolved in the translator phase. Ultimately this should be part of `sphinx-exercise`. 

- [x] support titles for `sphinx-exercise` exercise directives that are labeled (i.e. enumerated)